### PR TITLE
Pass parsed json response for errors to be compatible with boto 2.3

### DIFF
--- a/asyncdynamo/asyncdynamo.py
+++ b/asyncdynamo/asyncdynamo.py
@@ -213,7 +213,7 @@ class AsyncDynamoDB(AWSAuthConnection):
             else:
                 # because some errors are benign, include the response when an error is passed
                 return callback(json_response, error=DynamoDBResponseError(response.error.code, 
-                    response.error.message, response.body))
+                    response.error.message, json_response))
         return callback(json_response, error=None)
     
     def get_item(self, table_name, key, callback, attributes_to_get=None,

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
     ],
     packages=['asyncdynamo'],
-    install_requires=['tornado', 'boto'],
+    install_requires=['tornado', 'boto>=2.3.0'],
     requires=['tornado'],
     download_url="http://github.com/downloads/bitly/asyncdynamo/asyncdynamo-%s.tar.gz" % version,
 )


### PR DESCRIPTION
The API for DynamoDBResponseError changed as a result of
https://github.com/boto/boto/issues/625
